### PR TITLE
Support highlighting of switch/case

### DIFF
--- a/syntax/bro.vim
+++ b/syntax/bro.vim
@@ -20,6 +20,7 @@ syn keyword broStatement     alarm using of add delete
 syn keyword broStatement     default export event
 syn keyword broStatement     print redef return schedule
 syn keyword broStatement     when timeout
+syn keyword broStatement     switch case as
 
 syn keyword broStorageClass  local const global
 


### PR DESCRIPTION
This PR adds highlighting for the `switch` and `case` statements that are now available in Bro.